### PR TITLE
Fix findCycles to return single-node cycles

### DIFF
--- a/lib/alg/find-cycles.js
+++ b/lib/alg/find-cycles.js
@@ -4,5 +4,7 @@ var _ = require("../lodash"),
 module.exports = findCycles;
 
 function findCycles(g) {
-  return _.filter(tarjan(g), function(cmpt) { return cmpt.length > 1; });
+  return _.filter(tarjan(g), function(cmpt) {
+    return cmpt.length > 1 || (cmpt.length === 1 && g.hasEdge(cmpt[0], cmpt[0]));
+  });
 }

--- a/test/alg/find-cycles-test.js
+++ b/test/alg/find-cycles-test.js
@@ -14,7 +14,13 @@ describe("alg.findCycles", function() {
     expect(findCycles(g)).to.eql([]);
   });
 
-  it("returns a single entry for a cycle of 1 edge", function() {
+  it("returns a single entry for a cycle of 1 node", function() {
+    var g = new Graph();
+    g.setPath(["a", "a"]);
+    expect(sort(findCycles(g))).to.eql([["a"]]);
+  });
+
+  it("returns a single entry for a cycle of 2 nodes", function() {
     var g = new Graph();
     g.setPath(["a", "b", "a"]);
     expect(sort(findCycles(g))).to.eql([["a", "b"]]);
@@ -30,8 +36,9 @@ describe("alg.findCycles", function() {
     var g = new Graph();
     g.setPath(["a", "b", "a"]);
     g.setPath(["c", "d", "e", "c"]);
-    g.setNode("f");
-    expect(sort(findCycles(g))).to.eql([["a", "b"], ["c", "d", "e"]]);
+    g.setPath(["f", "g", "g"]);
+    g.setNode("h");
+    expect(sort(findCycles(g))).to.eql([["a", "b"], ["c", "d", "e"], ["g"]]);
   });
 });
 

--- a/test/alg/is-acyclic-test.js
+++ b/test/alg/is-acyclic-test.js
@@ -2,7 +2,7 @@ var expect = require("../chai").expect,
     Graph = require("../..").Graph,
     isAcyclic = require("../..").alg.isAcyclic;
 
-describe("alg.isAcylic", function() {
+describe("alg.isAcyclic", function() {
   it("returns true if the graph has no cycles", function() {
     var g = new Graph();
     g.setPath(["a", "b", "c"]);

--- a/test/alg/is-acylic-test.js
+++ b/test/alg/is-acylic-test.js
@@ -15,6 +15,12 @@ describe("alg.isAcylic", function() {
     expect(isAcyclic(g)).to.be.false;
   });
 
+  it("returns false if the graph has a cycle of 1 node", function() {
+    var g = new Graph();
+    g.setPath(["a", "a"]);
+    expect(isAcyclic(g)).to.be.false;
+  });
+
   it("rethrows non-CycleException errors", function() {
     expect(function() { isAcyclic(undefined); }).to.throw();
   });


### PR DESCRIPTION
Behaviour now matches that of isAcyclic (previously, for the graph a -> a, isAcyclic would return false while findCycles would return an empty set).