### PR TITLE
#33 compatibility: eachNode,eachEdge,filterNodes

### DIFF
--- a/lib/graph.js
+++ b/lib/graph.js
@@ -268,6 +268,27 @@ Graph.prototype.neighbors = function(v) {
   }
 };
 
+Graph.prototype.eachNode = function(func) {
+  for (var id in this._nodes) {
+    func(id, this._nodes[id]);
+  }
+};
+
+Graph.prototype.filterNodes = function(filter) {
+  var copy = new this.constructor();
+  copy.graph(this.graph());
+  this.eachNode(function(u, value) {
+    if (filter(u)) {
+      copy.setNode(u, value);
+    }
+  });
+  this.eachEdge(function(id, v, w, value) {
+    if (copy.hasNode(v) && copy.hasNode(w)) {
+      copy.setEdge(v, w, value);
+    }
+  });
+  return copy;
+};
 /* === Edge functions ========== */
 
 Graph.prototype.setDefaultEdgeLabel = function(newDefault) {
@@ -425,6 +446,14 @@ Graph.prototype.nodeEdges = function(v, w) {
   var inEdges = this.inEdges(v, w);
   if (inEdges) {
     return inEdges.concat(this.outEdges(v, w));
+  }
+};
+
+Graph.prototype.eachEdge = function(func) {
+  var id, edge;
+  for (id in this._edgeObjs) {
+    edge=this._edgeObjs[id];
+    func(id, edge.v, edge.w, this._edgeLabels[id]);
   }
 };
 


### PR DESCRIPTION
Fixed issue #33 Graph.filterNodes is not available anymore to be
compatible with previous releases