### PR TITLE
lodash.js made webpack compatible

### DIFF
--- a/lib/lodash.js
+++ b/lib/lodash.js
@@ -2,7 +2,7 @@
 
 var lodash;
 
-if (require) {
+if (typeof require === 'function') {
   try {
     lodash = require("lodash");
   } catch (e) {}


### PR DESCRIPTION
Avoiding the warning:

```
WARNING in ./~/graphlib/lib/lodash.js
Critical dependencies:
5:3-10 require function is used in a way, in which dependencies cannot be statically extracted
``
`

thrown by webpack.